### PR TITLE
Update to newer C standard and make OpenCV optional in basic API

### DIFF
--- a/src/exf1Opencv.h
+++ b/src/exf1Opencv.h
@@ -1,3 +1,4 @@
 
+#define EXF1API_WITH_OPENCV
 #include "exf1api.h"
 #include <highgui.h>

--- a/src/exf1api.cpp
+++ b/src/exf1api.cpp
@@ -341,6 +341,7 @@ static const char * const cdjpeg_message_table[] = {
   NULL
 };
 
+#ifdef EXF1API_WITH_OPENCV
 void exf1api::getCameraFrame(IplImage* frame)
 {
     char jpgImage[3*IMG_BUF_SIZE];
@@ -392,6 +393,7 @@ void exf1api::getCameraFrame(IplImage* frame)
     else
         printf("JPG size is negative!\n"); 
 }
+#endif // EXF1API_WITH_OPENCV
 
 void exf1api::terminateCamera(void)
 {

--- a/src/exf1api.h
+++ b/src/exf1api.h
@@ -9,10 +9,12 @@
 #define	EXF1API_H
 
 #include "libexf1.h"
+#ifdef EXF1API_WITH_OPENCV
 #define CV_NO_BACKWARD_COMPATIBILITY
 #include <cv.h>
-#include <ctype.h>
 #include <jpeglib.h>
+#endif  // EXF1API_WITH_OPENCV
+#include <ctype.h>
 //#include <cderror.h>
 
 #define JMESSAGE(code,string) string ,
@@ -57,7 +59,9 @@ class exf1api {
 	void focus(char focusIn, char continousFocus);
 
 	int grapPcMonitorFrame(const char *jpgImage);
-	void getCameraFrame(IplImage* frame); 
+#ifdef EXF1API_WITH_OPENCV
+	void getCameraFrame(IplImage* frame);
+#endif
 	void exitCamera(void);
 
 	libexf1 lib; 

--- a/src/exf1ctrl.cpp
+++ b/src/exf1ctrl.cpp
@@ -117,7 +117,7 @@ int main(int argc, char** argv)
    {
       printf("> ");
       
-      gets(input);
+      fgets(input, 64, stdin);
       sscanf(input, "%c", &com);
       
       switch (com) {

--- a/src/libexf1.cpp
+++ b/src/libexf1.cpp
@@ -161,7 +161,7 @@ void libexf1::exf1Cmd(WORD cmd, ...)
         case CMD_GET_OBJECT:
             wordVal  = va_arg(ap, int); // File/memory destination.
             dwordVal = va_arg(ap, int); // objectHandle
-            pString = (char *) va_arg(ap, int); //
+            pString = va_arg(ap, char *); //
             
             switch (wordVal) {
                 case TO_FILE:
@@ -170,7 +170,7 @@ void libexf1::exf1Cmd(WORD cmd, ...)
                     usbRx();
                     break;
                 case TO_MEM:
-                    pInt = (int *) va_arg(ap, int); //
+                    pInt = va_arg(ap, int *); //
 					do {
 						usbTx(cmd, TYPE_CMD, sizeof(DWORD), dwordVal, 0);
 						usbRxToMem(pString, pInt);


### PR DESCRIPTION
I've updated some deprecated usage of `gets` and `va_arg` and also made the OpenCV (and jpeg) optional in the basic API, so that is not necessary to have these larger libraries for the simple `exf1ctrl` project.